### PR TITLE
[WIP][Issue #4276] Upgrade geoserver for Python 2.7/3 compatibility (testing)

### DIFF
--- a/geonode/geoserver/createlayer/utils.py
+++ b/geonode/geoserver/createlayer/utils.py
@@ -23,6 +23,8 @@ import uuid
 import logging
 import json
 
+from six import string_types
+
 from django.template.defaultfilters import slugify
 
 from geoserver.catalog import FailedRequestError
@@ -165,7 +167,7 @@ def get_or_create_datastore(cat, workspace=None, charset="UTF-8"):
          'fetch size': '1000',
          'host': db['HOST'],
          'port': db['PORT'] if isinstance(
-             db['PORT'], basestring) else str(db['PORT']) or '5432',
+             db['PORT'], string_types) else str(db['PORT']) or '5432',
          'database': db['NAME'],
          'user': db['USER'],
          'passwd': db['PASSWORD'],

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -17,11 +17,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 #########################################################################
+from __future__ import print_function
+
 from collections import namedtuple, defaultdict
 import datetime
 from decimal import Decimal
 import errno
-from itertools import cycle, izip
+from itertools import cycle
+from six import (
+    python_2_unicode_compatible,
+    string_types,
+    text_type,
+    reraise as raise_
+)
 import json
 import logging
 import traceback
@@ -33,8 +41,11 @@ from threading import local
 import time
 import uuid
 # import base64
-import urllib
-from urlparse import urlsplit, urljoin
+try:
+    from urllib.parse import urlencode, urlsplit, urljoin
+except ImportError:
+    from urllib import urlencode
+    from urlparse import urlsplit, urljoin
 
 from pinax.ratings.models import OverallRating
 from bs4 import BeautifulSoup
@@ -300,7 +311,7 @@ def get_sld_for(gs_catalog, layer):
     # layers we should use that rather than guessing based on the auto-detected
     # style.
     if name in _style_templates:
-        fg, bg, mark = _style_contexts.next()
+        fg, bg, mark = next(_style_contexts)
         return _style_templates[name] % dict(
             name=layer.name,
             fg=fg,
@@ -556,7 +567,7 @@ def gs_slurp(
     if console is None:
         console = open(os.devnull, 'w')
     if verbosity > 0:
-        print >> console, "Inspecting the available layers in GeoServer ..."
+        print("Inspecting the available layers in GeoServer ...", file=console)
     cat = gs_catalog
     if workspace is not None:
         workspace = cat.get_workspace(workspace)
@@ -623,7 +634,7 @@ def gs_slurp(
     number = len(resources)
     if verbosity > 0:
         msg = "Found %d layers, starting processing" % number
-        print >> console, msg
+        print(msg, file=console)
     output = {
         'stats': {
             'failed': 0,
@@ -646,7 +657,7 @@ def gs_slurp(
                 "storeType": the_store.resource_type,
                 "alternate": "%s:%s" % (workspace.name.encode('utf-8'), resource.name.encode('utf-8')),
                 "title": resource.title or 'No title provided',
-                "abstract": resource.abstract or unicode(_('No abstract provided')).encode('utf-8'),
+                "abstract": resource.abstract or str(_('No abstract provided')).encode('utf-8'),
                 "owner": owner,
                 "uuid": str(uuid.uuid4())
             })
@@ -686,10 +697,12 @@ def gs_slurp(
             else:
                 if verbosity > 0:
                     msg = "Stopping process because --ignore-errors was not set and an error was found."
-                    print >> sys.stderr, msg
-                raise Exception(
-                    'Failed to process %s' %
-                    resource.name.encode('utf-8'), e), None, sys.exc_info()[2]
+                    print(msg, file=sys.stderr)
+                raise_(
+                    Exception,
+                    Exception("Failed to process {}".format(resource.name.encode('utf-8')), e),
+                    sys.exc_info()[2]
+                )
         else:
             if created:
                 if not permissions:
@@ -712,7 +725,7 @@ def gs_slurp(
             info['error'] = error
         output['layers'].append(info)
         if verbosity > 0:
-            print >> console, msg
+            print(msg, file=console)
 
     if remove_deleted:
         q = Layer.objects.filter()
@@ -767,7 +780,7 @@ def gs_slurp(
         if verbosity > 0:
             msg = "\nFound %d layers to delete, starting processing" % number_deleted if number_deleted > 0 else \
                 "\nFound %d layers to delete" % number_deleted
-            print >> console, msg
+            print(msg, file=console)
 
         for i, layer in enumerate(deleted_layers):
             logger.debug(
@@ -807,7 +820,7 @@ def gs_slurp(
                 info['error'] = error
             output['deleted_layers'].append(info)
             if verbosity > 0:
-                print >> console, msg
+                print(msg, file=console)
 
     finish = datetime.datetime.now(timezone.get_current_timezone())
     td = finish - start
@@ -944,11 +957,11 @@ def set_attributes_from_geoserver(layer, overwrite=False):
         typename = layer.alternate.encode('utf-8') if layer.alternate else layer.typename.encode('utf-8')
         dft_url = re.sub(r"\/wms\/?$",
                          "/",
-                         server_url) + "ows?" + urllib.urlencode({"service": "wfs",
-                                                                  "version": "1.0.0",
-                                                                  "request": "DescribeFeatureType",
-                                                                  "typename": typename,
-                                                                  })
+                         server_url) + "ows?" + urlencode({"service": "wfs",
+                                                           "version": "1.0.0",
+                                                           "request": "DescribeFeatureType",
+                                                           "typename": typename,
+                                                          })
         try:
             # The code below will fail if http_client cannot be imported or WFS not supported
             req, body = http_client.get(dft_url, user=_user)
@@ -962,7 +975,7 @@ def set_attributes_from_geoserver(layer, overwrite=False):
             logger.debug(tb)
             attribute_map = []
             # Try WMS instead
-            dft_url = server_url + "?" + urllib.urlencode({
+            dft_url = server_url + "?" + urlencode({
                 "service": "wms",
                 "version": "1.0.0",
                 "request": "GetFeatureInfo",
@@ -992,7 +1005,7 @@ def set_attributes_from_geoserver(layer, overwrite=False):
                 attribute_map = []
     elif layer.storeType in ["coverageStore"]:
         typename = layer.alternate.encode('utf-8') if layer.alternate else layer.typename.encode('utf-8')
-        dc_url = server_url + "wcs?" + urllib.urlencode({
+        dc_url = server_url + "wcs?" + urlencode({
             "service": "wcs",
             "version": "1.1.0",
             "request": "DescribeCoverage",
@@ -1315,7 +1328,7 @@ def create_geoserver_db_featurestore(
              'Test while idle': 'true',
              'host': db['HOST'],
              'port': db['PORT'] if isinstance(
-                 db['PORT'], basestring) else str(db['PORT']) or '5432',
+                 db['PORT'], string_types) else str(db['PORT']) or '5432',
              'database': db['NAME'],
              'user': db['USER'],
              'passwd': db['PASSWORD'],
@@ -1392,7 +1405,7 @@ def _create_db_featurestore(name, data, overwrite=False, charset="UTF-8", worksp
 def get_store(cat, name, workspace=None):
     # Make sure workspace is a workspace object and not a string.
     # If the workspace does not exist, continue as if no workspace had been defined.
-    if isinstance(workspace, basestring):
+    if isinstance(workspace, string_types):
         workspace = cat.get_workspace(workspace)
 
     if workspace is None:
@@ -1897,7 +1910,7 @@ _backgrounds = [
     "#008888",
     "#880088"]
 _marks = ["square", "circle", "cross", "x", "triangle"]
-_style_contexts = izip(cycle(_foregrounds), cycle(_backgrounds), cycle(_marks))
+_style_contexts = zip(cycle(_foregrounds), cycle(_backgrounds), cycle(_marks))
 _default_style_names = ["point", "line", "polygon", "raster"]
 _esri_types = {
     "esriFieldTypeDouble": "xsd:double",
@@ -1914,6 +1927,7 @@ _esri_types = {
     "esriFieldTypeXML": "xsd:anyType"}
 
 
+@python_2_unicode_compatible
 def _render_thumbnail(req_body, width=240, height=180):
     spec = _fixup_ows_url(req_body)
     url = "%srest/printng/render.png" % ogc_server_settings.LOCATION
@@ -1921,7 +1935,7 @@ def _render_thumbnail(req_body, width=240, height=180):
     # valid_uname_pw = base64.b64encode(b"%s:%s" % (_user, _password)).decode("ascii")
     # headers['Authorization'] = 'Basic {}'.format(valid_uname_pw)
     params = dict(width=width, height=height)
-    url = url + "?" + urllib.urlencode(params)
+    url += "?" + urlencode(params)
 
     # @todo annoying but not critical
     # openlayers controls posted back contain a bad character. this seems
@@ -1929,12 +1943,12 @@ def _render_thumbnail(req_body, width=240, height=180):
     # to a unicode en-dash but is not uncoded properly during transmission
     # 'ignore' the error for now as controls are not being rendered...
     data = spec
-    if isinstance(data, unicode):
+    if isinstance(data, text_type):
         # make sure any stored bad values are wiped out
         # don't use keyword for errors - 2.6 compat
         # though unicode accepts them (as seen below)
         data = data.encode('ASCII', 'ignore')
-    data = unicode(data, errors='ignore').encode('UTF-8')
+    data = str(data, errors='ignore').encode('UTF-8')
     try:
         req, content = http_client.request(
             url,
@@ -1975,7 +1989,7 @@ def _prepare_thumbnail_body_from_opts(request_body, request=None):
         width = 240
         height = 200
 
-        if isinstance(request_body, basestring):
+        if isinstance(request_body, string_types):
             try:
                 request_body = json.loads(request_body)
             except BaseException:

--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -546,6 +546,7 @@ def delete_from_postgis(layer_name, store):
             logger.error("Error closing PostGIS conn %s:%s", layer_name, str(e))
 
 
+@python_2_unicode_compatible
 def gs_slurp(
         ignore_errors=True,
         verbosity=1,

--- a/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
+++ b/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
@@ -77,19 +77,24 @@ class Command(BaseCommand):
         for layer in layers:
             count += 1
             try:
-                print 'Checking layer %s/%s: %s owned by %s' % (count,
-                                                                layers_count,
-                                                                layer.alternate,
-                                                                layer.owner.username)
+                print("Checking layer {}/{}: {} owned by {}".format(
+                    count,
+                    layers_count,
+                    layer.alternate,
+                    layer.owner.username
+                ))
                 if not is_gs_resource_valid(layer):
-                    print 'Layer %s is broken!' % layer.alternate
+                    print("Layer {} is broken!".format(layer.alternate))
                     layer_errors.append(layer)
                     if options['remove']:
-                        print 'Removing this layer...'
+                        print("Removing this layer...")
                         layer.delete()
             except:
                 print("Unexpected error:", sys.exc_info()[0])
 
-        print '\n***** Layers with errors: %s in a total of %s *****' % (len(layer_errors), layers_count)
+        print("\n***** Layers with errors: {} in a total of {} *****".format(
+            len(layer_errors),
+            layers_count
+        ))
         for layer_error in layer_errors:
-            print '%s by %s' % (layer_error.alternate, layer_error.owner.username)
+            print("{} by {}".format(layer_error.alternate, layer_error.owner.username))

--- a/geonode/geoserver/management/commands/sync_geonode_layers.py
+++ b/geonode/geoserver/management/commands/sync_geonode_layers.py
@@ -44,9 +44,9 @@ def sync_geonode_layers(ignore_errors, filter, username,
     for layer in layers:
         try:
             count += 1
-            print 'Syncing layer %s/%s: %s' % (count, layers_count, layer.name)
+            print("Syncing layer {}/{}: {}".format(count, layers_count, layer.name))
             if updatepermissions:
-                print 'Syncing permissions...'
+                print("Syncing permissions...")
                 # sync permissions in GeoFence
                 perm_spec = json.loads(_perms_info_json(layer))
                 # re-sync GeoFence security rules
@@ -55,22 +55,22 @@ def sync_geonode_layers(ignore_errors, filter, username,
                 # recalculate the layer statistics
                 set_attributes_from_geoserver(layer, overwrite=True)
             if updatethumbnails:
-                print 'Regenerating thumbnails...'
+                print("Regenerating thumbnails...")
                 layer.save()
         except Exception:
             layer_errors.append(layer.alternate)
             exception_type, error, traceback = sys.exc_info()
-            print exception_type, error, traceback
+            print(exception_type, error, traceback)
             if ignore_errors:
                 pass
             else:
                 import traceback
                 traceback.print_exc()
-                print 'Stopping process because --ignore-errors was not set and an error was found.'
+                print("Stopping process because --ignore-errors was not set and an error was found.")
                 return
-    print 'There are %s layers which could not be updated because of errors' % len(layer_errors)
+    print("There are {} layers which could not be updated because of errors".format(len(layer_errors))
     for layer_error in layer_errors:
-        print layer_error
+        print(layer_error)
 
 
 class Command(BaseCommand):

--- a/geonode/geoserver/management/commands/updatelayers.py
+++ b/geonode/geoserver/management/commands/updatelayers.py
@@ -124,34 +124,34 @@ class Command(BaseCommand):
             execute_signals=True)
 
         if verbosity > 1:
-            print "\nDetailed report of failures:"
+            print("\nDetailed report of failures:")
             for dict_ in output['layers']:
                 if dict_['status'] == 'failed':
-                    print "\n\n", dict_['name'], "\n================"
+                    print("\n\n", dict_['name'], "\n================")
                     traceback.print_exception(dict_['exception_type'],
                                               dict_['error'],
                                               dict_['traceback'])
             if remove_deleted:
-                print "Detailed report of layers to be deleted from GeoNode that failed:"
+                print("Detailed report of layers to be deleted from GeoNode that failed:")
                 for dict_ in output['deleted_layers']:
                     if dict_['status'] == 'delete_failed':
-                        print "\n\n", dict_['name'], "\n================"
+                        print("\n\n", dict_['name'], "\n================")
                         traceback.print_exception(dict_['exception_type'],
                                                   dict_['error'],
                                                   dict_['traceback'])
 
         if verbosity > 0:
-            print "\n\nFinished processing %d layers in %s seconds.\n" % (
-                len(output['layers']), round(output['stats']['duration_sec'], 2))
-            print "%d Created layers" % output['stats']['created']
-            print "%d Updated layers" % output['stats']['updated']
-            print "%d Failed layers" % output['stats']['failed']
+            print("\n\nFinished processing {} layers in {} seconds.\n".format(
+                len(output['layers']), round(output['stats']['duration_sec'], 2)))
+            print("{} Created layers".format(output['stats']['created'])
+            print("{} Updated layers".format(output['stats']['updated'])
+            print("{} Failed layers".format(output['stats']['failed'])
             try:
                 duration_layer = round(
                     output['stats']['duration_sec'] * 1.0 / len(output['layers']), 2)
             except ZeroDivisionError:
                 duration_layer = 0
             if len(output) > 0:
-                print "%f seconds per layer" % duration_layer
+                print("{} seconds per layer".format(duration_layer)
             if remove_deleted:
-                print "\n%d Deleted layers" % output['stats']['deleted']
+                print("\n{} Deleted layers".format(output['stats']['deleted'])

--- a/geonode/geoserver/ows.py
+++ b/geonode/geoserver/ows.py
@@ -23,8 +23,11 @@ import logging
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
-import urllib
-from urlparse import urljoin
+try:
+    from urllib.parse import urlencode, urljoin
+except ImportError:
+    from urllib import urlencode
+    from urlparse import urljoin
 
 from .helpers import OGC_Servers_Handler
 
@@ -42,7 +45,7 @@ def _wcs_get_capabilities():
         wcs_url = urljoin(ogc_settings.PUBLIC_LOCATION, 'ows')
     wcs_url += '&' if '?' in wcs_url else '?'
 
-    return wcs_url + urllib.urlencode({
+    return wcs_url + urlencode({
         'service': 'WCS',
         'request': 'GetCapabilities',
         'version': '2.0.1',
@@ -61,7 +64,7 @@ def _wcs_link(wcs_url, identifier, mime, srid=None, bbox=None):
         wcs_params['srs'] = srid
     if bbox:
         wcs_params['bbox'] = bbox
-    return wcs_url + urllib.urlencode(wcs_params)
+    return wcs_url + urlencode(wcs_params)
 
 
 def wcs_links(wcs_url, identifier, bbox=None, srid=None):
@@ -83,7 +86,7 @@ def _wfs_get_capabilities():
         wfs_url = urljoin(ogc_settings.PUBLIC_LOCATION, 'ows')
     wfs_url += '&' if '?' in wfs_url else '?'
 
-    return wfs_url + urllib.urlencode({
+    return wfs_url + urlencode({
         'service': 'WFS',
         'request': 'GetCapabilities',
         'version': '1.1.0',
@@ -103,7 +106,7 @@ def _wfs_link(wfs_url, identifier, mime, extra_params, bbox=None, srid=None):
     if bbox:
         params['bbox'] = bbox
     params.update(extra_params)
-    return wfs_url + urllib.urlencode(params)
+    return wfs_url + urlencode(params)
 
 
 def wfs_links(wfs_url, identifier, bbox=None, srid=None):
@@ -129,7 +132,7 @@ def _wms_get_capabilities():
         wms_url = urljoin(ogc_settings.PUBLIC_LOCATION, 'ows')
     wms_url += '&' if '?' in wms_url else '?'
 
-    return wms_url + urllib.urlencode({
+    return wms_url + urlencode({
         'service': 'WMS',
         'request': 'GetCapabilities',
         'version': '1.3.0',
@@ -150,7 +153,7 @@ def _wms_link(wms_url, identifier, mime, height, width, srid=None, bbox=None):
     if bbox:
         wms_params['bbox'] = bbox
 
-    return wms_url + urllib.urlencode(wms_params)
+    return wms_url + urlencode(wms_params)
 
 
 def wms_links(wms_url, identifier, bbox, srid, height, width):

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -27,7 +27,11 @@ from lxml import etree
 from defusedxml import lxml as dlxml
 from os.path import isfile
 
-from urlparse import urlsplit, urljoin
+try:
+    from urllib.parse import urlsplit, urljoin, unquote
+except ImportError:
+    from urllib import unquote
+    from urlparse import urlsplit, urljoin
 
 from django.contrib.auth import authenticate
 from django.http import HttpResponse, HttpResponseRedirect
@@ -119,8 +123,7 @@ def layer_style(request, layername):
     # that the new default style name is included
     # in the list of possible styles.
 
-    new_style = (
-        style for style in layer.styles if style.name == style_name).next()
+    new_style = next(style for style in layer.styles if style.name == style_name)
 
     # Does this change this in geoserver??
     layer.default_style = new_style
@@ -524,8 +527,7 @@ def geoserver_proxy(request,
                     logger.warn("Could not find any Layer %s on DB" % os.path.basename(request.path))
 
     kwargs = {'affected_layers': affected_layers}
-    import urllib
-    raw_url = urllib.unquote(raw_url).decode('utf8')
+    raw_url = unquote(raw_url).decode('utf8')
     timeout = getattr(ogc_server_settings, 'TIMEOUT') or 10
     allowed_hosts = [urlsplit(ogc_server_settings.public_url).hostname, ]
     return proxy(request, url=raw_url, response_callback=_response_callback,


### PR DESCRIPTION
PR to update `geoserver` app to be Python 2.7/3 cross-compatible as part of #4276.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
