### PR TITLE
[Issue #4276] Upgrade geoserver for Python 2.7/3 compatibility

### DIFF
--- a/geonode/geoserver/createlayer/utils.py
+++ b/geonode/geoserver/createlayer/utils.py
@@ -23,6 +23,8 @@ import uuid
 import logging
 import json
 
+from six import string_types
+
 from django.template.defaultfilters import slugify
 
 from geoserver.catalog import FailedRequestError
@@ -165,7 +167,7 @@ def get_or_create_datastore(cat, workspace=None, charset="UTF-8"):
          'fetch size': '1000',
          'host': db['HOST'],
          'port': db['PORT'] if isinstance(
-             db['PORT'], basestring) else str(db['PORT']) or '5432',
+             db['PORT'], string_types) else str(db['PORT']) or '5432',
          'database': db['NAME'],
          'user': db['USER'],
          'passwd': db['PASSWORD'],

--- a/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
+++ b/geonode/geoserver/management/commands/find_geoserver_broken_layers.py
@@ -77,19 +77,24 @@ class Command(BaseCommand):
         for layer in layers:
             count += 1
             try:
-                print 'Checking layer %s/%s: %s owned by %s' % (count,
-                                                                layers_count,
-                                                                layer.alternate,
-                                                                layer.owner.username)
+                print("Checking layer {}/{}: {} owned by {}".format(
+                    count,
+                    layers_count,
+                    layer.alternate,
+                    layer.owner.username
+                ))
                 if not is_gs_resource_valid(layer):
-                    print 'Layer %s is broken!' % layer.alternate
+                    print("Layer {} is broken!".format(layer.alternate))
                     layer_errors.append(layer)
                     if options['remove']:
-                        print 'Removing this layer...'
+                        print("Removing this layer...")
                         layer.delete()
             except:
                 print("Unexpected error:", sys.exc_info()[0])
 
-        print '\n***** Layers with errors: %s in a total of %s *****' % (len(layer_errors), layers_count)
+        print("\n***** Layers with errors: {} in a total of {} *****".format(
+            len(layer_errors),
+            layers_count
+        ))
         for layer_error in layer_errors:
-            print '%s by %s' % (layer_error.alternate, layer_error.owner.username)
+            print("{} by {}".format(layer_error.alternate, layer_error.owner.username))

--- a/geonode/geoserver/management/commands/sync_geonode_layers.py
+++ b/geonode/geoserver/management/commands/sync_geonode_layers.py
@@ -44,9 +44,9 @@ def sync_geonode_layers(ignore_errors, filter, username,
     for layer in layers:
         try:
             count += 1
-            print 'Syncing layer %s/%s: %s' % (count, layers_count, layer.name)
+            print("Syncing layer {}/{}: {}".format(count, layers_count, layer.name))
             if updatepermissions:
-                print 'Syncing permissions...'
+                print("Syncing permissions...")
                 # sync permissions in GeoFence
                 perm_spec = json.loads(_perms_info_json(layer))
                 # re-sync GeoFence security rules
@@ -55,22 +55,22 @@ def sync_geonode_layers(ignore_errors, filter, username,
                 # recalculate the layer statistics
                 set_attributes_from_geoserver(layer, overwrite=True)
             if updatethumbnails:
-                print 'Regenerating thumbnails...'
+                print("Regenerating thumbnails...")
                 layer.save()
         except Exception:
             layer_errors.append(layer.alternate)
             exception_type, error, traceback = sys.exc_info()
-            print exception_type, error, traceback
+            print(exception_type, error, traceback)
             if ignore_errors:
                 pass
             else:
                 import traceback
                 traceback.print_exc()
-                print 'Stopping process because --ignore-errors was not set and an error was found.'
+                print("Stopping process because --ignore-errors was not set and an error was found.")
                 return
-    print 'There are %s layers which could not be updated because of errors' % len(layer_errors)
+    print("There are {} layers which could not be updated because of errors".format(len(layer_errors))
     for layer_error in layer_errors:
-        print layer_error
+        print(layer_error)
 
 
 class Command(BaseCommand):

--- a/geonode/geoserver/management/commands/updatelayers.py
+++ b/geonode/geoserver/management/commands/updatelayers.py
@@ -124,34 +124,34 @@ class Command(BaseCommand):
             execute_signals=True)
 
         if verbosity > 1:
-            print "\nDetailed report of failures:"
+            print("\nDetailed report of failures:")
             for dict_ in output['layers']:
                 if dict_['status'] == 'failed':
-                    print "\n\n", dict_['name'], "\n================"
+                    print("\n\n", dict_['name'], "\n================")
                     traceback.print_exception(dict_['exception_type'],
                                               dict_['error'],
                                               dict_['traceback'])
             if remove_deleted:
-                print "Detailed report of layers to be deleted from GeoNode that failed:"
+                print("Detailed report of layers to be deleted from GeoNode that failed:")
                 for dict_ in output['deleted_layers']:
                     if dict_['status'] == 'delete_failed':
-                        print "\n\n", dict_['name'], "\n================"
+                        print("\n\n", dict_['name'], "\n================")
                         traceback.print_exception(dict_['exception_type'],
                                                   dict_['error'],
                                                   dict_['traceback'])
 
         if verbosity > 0:
-            print "\n\nFinished processing %d layers in %s seconds.\n" % (
-                len(output['layers']), round(output['stats']['duration_sec'], 2))
-            print "%d Created layers" % output['stats']['created']
-            print "%d Updated layers" % output['stats']['updated']
-            print "%d Failed layers" % output['stats']['failed']
+            print("\n\nFinished processing {} layers in {} seconds.\n".format(
+                len(output['layers']), round(output['stats']['duration_sec'], 2)))
+            print("{} Created layers".format(output['stats']['created'])
+            print("{} Updated layers".format(output['stats']['updated'])
+            print("{} Failed layers".format(output['stats']['failed'])
             try:
                 duration_layer = round(
                     output['stats']['duration_sec'] * 1.0 / len(output['layers']), 2)
             except ZeroDivisionError:
                 duration_layer = 0
             if len(output) > 0:
-                print "%f seconds per layer" % duration_layer
+                print("{} seconds per layer".format(duration_layer)
             if remove_deleted:
-                print "\n%d Deleted layers" % output['stats']['deleted']
+                print("\n{} Deleted layers".format(output['stats']['deleted'])

--- a/geonode/geoserver/ows.py
+++ b/geonode/geoserver/ows.py
@@ -23,8 +23,11 @@ import logging
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
-import urllib
-from urlparse import urljoin
+try:
+    from urllib.parse import urlencode, urljoin
+except ImportError:
+    from urllib import urlencode
+    from urlparse import urljoin
 
 from .helpers import OGC_Servers_Handler
 
@@ -42,7 +45,7 @@ def _wcs_get_capabilities():
         wcs_url = urljoin(ogc_settings.PUBLIC_LOCATION, 'ows')
     wcs_url += '&' if '?' in wcs_url else '?'
 
-    return wcs_url + urllib.urlencode({
+    return wcs_url + urlencode({
         'service': 'WCS',
         'request': 'GetCapabilities',
         'version': '2.0.1',
@@ -61,7 +64,7 @@ def _wcs_link(wcs_url, identifier, mime, srid=None, bbox=None):
         wcs_params['srs'] = srid
     if bbox:
         wcs_params['bbox'] = bbox
-    return wcs_url + urllib.urlencode(wcs_params)
+    return wcs_url + urlencode(wcs_params)
 
 
 def wcs_links(wcs_url, identifier, bbox=None, srid=None):
@@ -83,7 +86,7 @@ def _wfs_get_capabilities():
         wfs_url = urljoin(ogc_settings.PUBLIC_LOCATION, 'ows')
     wfs_url += '&' if '?' in wfs_url else '?'
 
-    return wfs_url + urllib.urlencode({
+    return wfs_url + urlencode({
         'service': 'WFS',
         'request': 'GetCapabilities',
         'version': '1.1.0',
@@ -103,7 +106,7 @@ def _wfs_link(wfs_url, identifier, mime, extra_params, bbox=None, srid=None):
     if bbox:
         params['bbox'] = bbox
     params.update(extra_params)
-    return wfs_url + urllib.urlencode(params)
+    return wfs_url + urlencode(params)
 
 
 def wfs_links(wfs_url, identifier, bbox=None, srid=None):
@@ -129,7 +132,7 @@ def _wms_get_capabilities():
         wms_url = urljoin(ogc_settings.PUBLIC_LOCATION, 'ows')
     wms_url += '&' if '?' in wms_url else '?'
 
-    return wms_url + urllib.urlencode({
+    return wms_url + urlencode({
         'service': 'WMS',
         'request': 'GetCapabilities',
         'version': '1.3.0',
@@ -150,7 +153,7 @@ def _wms_link(wms_url, identifier, mime, height, width, srid=None, bbox=None):
     if bbox:
         wms_params['bbox'] = bbox
 
-    return wms_url + urllib.urlencode(wms_params)
+    return wms_url + urlencode(wms_params)
 
 
 def wms_links(wms_url, identifier, bbox, srid, height, width):

--- a/geonode/geoserver/views.py
+++ b/geonode/geoserver/views.py
@@ -27,7 +27,11 @@ from lxml import etree
 from defusedxml import lxml as dlxml
 from os.path import isfile
 
-from urlparse import urlsplit, urljoin
+try:
+    from urllib.parse import urlsplit, urljoin, unquote
+except ImportError:
+    from urllib import unquote
+    from urlparse import urlsplit, urljoin
 
 from django.contrib.auth import authenticate
 from django.http import HttpResponse, HttpResponseRedirect
@@ -119,8 +123,7 @@ def layer_style(request, layername):
     # that the new default style name is included
     # in the list of possible styles.
 
-    new_style = (
-        style for style in layer.styles if style.name == style_name).next()
+    new_style = next(style for style in layer.styles if style.name == style_name)
 
     # Does this change this in geoserver??
     layer.default_style = new_style
@@ -524,8 +527,7 @@ def geoserver_proxy(request,
                     logger.warn("Could not find any Layer %s on DB" % os.path.basename(request.path))
 
     kwargs = {'affected_layers': affected_layers}
-    import urllib
-    raw_url = urllib.unquote(raw_url).decode('utf8')
+    raw_url = unquote(raw_url).decode('utf8')
     timeout = getattr(ogc_server_settings, 'TIMEOUT') or 10
     allowed_hosts = [urlsplit(ogc_server_settings.public_url).hostname, ]
     return proxy(request, url=raw_url, response_callback=_response_callback,


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
