### PR TITLE
[Issue #4276] Upgrade qgis_server for Python 2.7/3 compatibility

### DIFF
--- a/geonode/qgis_server/gis_tools.py
+++ b/geonode/qgis_server/gis_tools.py
@@ -20,7 +20,11 @@
 
 import logging
 import traceback
-from urllib import urlencode, urlretrieve
+try:
+    from urllib.parse import urlencode
+    from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlencode, urlretrieve
 from os.path import splitext
 from math import atan, degrees, sinh, pi
 from defusedxml import lxml as dlxml

--- a/geonode/qgis_server/helpers.py
+++ b/geonode/qgis_server/helpers.py
@@ -22,9 +22,12 @@ import math
 import os
 import re
 import shutil
-import urllib
 import json
-from urlparse import urljoin
+try:
+    from urllib.parse import unquote, urljoin
+except ImportError:
+    from urllib import unquote
+    from urlparse import urljoin
 
 import requests
 from django.conf import settings
@@ -189,7 +192,7 @@ def tile_url_format(layer_name, style=None):
         kwargs=url_kwargs)
     # unquote url
     # so that {z}/{x}/{y} is not quoted
-    url = urllib.unquote(url)
+    url = unquote(url)
     url = urljoin(settings.SITEURL, url)
     return url
 
@@ -934,35 +937,35 @@ def delete_orphaned_qgis_server_layers():
     """Delete orphaned QGIS Server files."""
     layer_path = settings.QGIS_SERVER_CONFIG['layer_directory']
     if not os.path.exists(layer_path):
-        print '{path} not exists'.format(path=layer_path)
+        print("{path} not exists".format(path=layer_path))
         return
     for filename in os.listdir(layer_path):
         basename, __ = os.path.splitext(filename)
         fn = os.path.join(layer_path, filename)
         if QGISServerLayer.objects.filter(
                 base_layer_path__icontains=basename).count() == 0:
-            print 'Removing orphan layer file %s' % fn
+            print("Removing orphan layer file {}".format(fn))
             try:
                 os.remove(fn)
             except OSError:
-                print 'Could not delete file %s' % fn
+                print("Could not delete file {}".format(fn))
 
 
 def delete_orphaned_qgis_server_caches():
     """Delete orphaned QGIS Server tile caches."""
     tiles_path = settings.QGIS_SERVER_CONFIG['tiles_directory']
     if not os.path.exists(tiles_path):
-        print '{path} not exists'.format(path=tiles_path)
+        print("{path} not exists".format(path=tiles_path))
         return
     for basename in os.listdir(tiles_path):
         path = os.path.join(tiles_path, basename)
         if QGISServerLayer.objects.filter(
                 base_layer_path__icontains=basename).count() == 0:
-            print 'Removing orphan layer file %s' % path
+            print("Removing orphan layer file {}".format(path))
             try:
                 shutil.rmtree(path)
             except OSError:
-                print 'Could not delete file %s' % path
+                print("Could not delete file {}".format(path))
 
 
 def get_model_path(instance):

--- a/geonode/qgis_server/management/commands/import_qgis_styles.py
+++ b/geonode/qgis_server/management/commands/import_qgis_styles.py
@@ -33,17 +33,16 @@ class Command(BaseCommand):
             try:
                 l.qgis_layer
             except:
-                print 'Layer %s has no associated qgis_layer' % l.name
+                print("Layer {} has no associated qgis_layer".format(l.name))
                 continue
 
             if l.qgis_layer:
-                print 'Fetching styles for layer %s' % l.name
+                print("Fetching styles for layer %s".format(l.name))
 
                 try:
                     styles = style_list(l, internal=False)
                 except:
-                    print 'Failed to fetch styles'
+                    print("Failed to fetch styles")
                     continue
 
-                print 'Successfully fetch %d style(s)' % len(styles)
-                print ''
+                print("Successfully fetch %d style(s)\n".format(len(styles))

--- a/geonode/qgis_server/tests/test_helpers.py
+++ b/geonode/qgis_server/tests/test_helpers.py
@@ -21,7 +21,10 @@
 from geonode.tests.base import GeoNodeBaseTestSupport
 
 import os
-import urlparse
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
 import unittest
 from imghdr import what
 
@@ -89,7 +92,7 @@ class HelperTest(GeoNodeBaseTestSupport):
         self.assertEqual(
             settings.QGIS_SERVER_URL, qgis_server_endpoint(internal=True))
         # Public url should go to proxy url
-        parse_result = urlparse.urlparse(qgis_server_endpoint(internal=False))
+        parse_result = urlparse(qgis_server_endpoint(internal=False))
         self.assertEqual(parse_result.path, reverse('qgis_server:request'))
 
     @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
@@ -106,13 +109,13 @@ class HelperTest(GeoNodeBaseTestSupport):
 
         qgis_tile_url = tile_url(uploaded, 11, 1576, 1054, internal=True)
 
-        parse_result = urlparse.urlparse(qgis_tile_url)
+        parse_result = urlparse(qgis_tile_url)
 
-        base_net_loc = urlparse.urlparse(settings.QGIS_SERVER_URL).netloc
+        base_net_loc = urlparse(settings.QGIS_SERVER_URL).netloc
 
         self.assertEqual(base_net_loc, parse_result.netloc)
 
-        query_string = urlparse.parse_qs(parse_result.query)
+        query_string = parse_qs(parse_result.query)
 
         expected_query_string = {
             'SERVICE': 'WMS',
@@ -130,7 +133,7 @@ class HelperTest(GeoNodeBaseTestSupport):
             'MAP_RESOLUTION': '96',
             'FORMAT_OPTIONS': 'dpi:96'
         }
-        for key, value in expected_query_string.iteritems():
+        for key, value in expected_query_string.items():
             # urlparse.parse_qs returned a dictionary of list
             actual_value = query_string[key][0]
             self.assertEqual(actual_value, value)

--- a/geonode/qgis_server/tests/test_management.py
+++ b/geonode/qgis_server/tests/test_management.py
@@ -21,7 +21,10 @@
 from geonode.tests.base import GeoNodeBaseTestSupport
 
 import os
-import urlparse
+try:
+    from urllib.parse import unquote
+except ImportError:
+    from urlparse import unquote
 from imghdr import what
 
 import gisdata
@@ -73,7 +76,7 @@ class TestManagementCommands(GeoNodeBaseTestSupport):
         tiles_link = layer.link_set.get(name='Tiles')
         """:type: geonode.base.models.Link"""
         self.assertEqual(tiles_link.extension, 'tiles')
-        tiles_url = urlparse.unquote(tiles_link.url)
+        tiles_url = unquote(tiles_link.url)
         tiles = {
             'z': 7,
             'x': 34,
@@ -118,7 +121,7 @@ class TestManagementCommands(GeoNodeBaseTestSupport):
             filepath = f.file.path
             __, extension = os.path.splitext(filepath)
             old_mtime = [
-                v for k, v in layer_modified_time.iteritems()
+                v for k, v in layer_modified_time.items()
                 if k.endswith(extension)][0]
             self.assertNotEqual(old_mtime, os.path.getmtime(filepath))
 
@@ -126,10 +129,10 @@ class TestManagementCommands(GeoNodeBaseTestSupport):
         # previous files should not exists
         for f in layer.upload_session.layerfile_set.all():
             filepath = f.file.path
-            if filepath not in layer_modified_time.iterkeys():
+            if filepath not in layer_modified_time.keys():
                 __, extension = os.path.splitext(filepath)
                 old_filepath = [
-                    k for k in layer_modified_time.iterkeys()
+                    k for k in layer_modified_time.keys()
                     if k.endswith(extension)][0]
                 self.assertFalse(os.path.exists(old_filepath))
 

--- a/geonode/qgis_server/tests/test_views.py
+++ b/geonode/qgis_server/tests/test_views.py
@@ -20,10 +20,13 @@
 
 from geonode.tests.base import GeoNodeBaseTestSupport
 
-import StringIO
+import io
 import json
 import os
-import urlparse
+try:
+    from urllib.parse import urlsplit, urlunsplit
+except ImportError:
+    from urlparse import urlsplit, urlunsplit
 import zipfile
 from imghdr import what
 
@@ -90,7 +93,7 @@ class QGISServerViewsTest(GeoNodeBaseTestSupport):
             reverse('qgis_server:download-zip', kwargs=params))
         self.assertEqual(response.status_code, 200)
         try:
-            f = StringIO.StringIO(response.content)
+            f = io.StringIO(response.content)
             zipped_file = zipfile.ZipFile(f, 'r')
 
             for one_file in zipped_file.namelist():
@@ -522,7 +525,7 @@ class QGISServerStyleManagerTest(GeoNodeBaseTestSupport):
         }
         actual_default_style_retval = json.loads(response.content)
 
-        for key, value in expected_default_style_retval.iteritems():
+        for key, value in expected_default_style_retval.items():
             self.assertEqual(actual_default_style_retval[key], value)
 
         layer.delete()
@@ -551,8 +554,8 @@ class ThumbnailGenerationTest(GeoNodeBaseTestSupport):
         remote_thumbnail_url = remote_thumbnail_link.url
 
         # Replace url's basename, we want to access it using django client
-        parse_result = urlparse.urlsplit(remote_thumbnail_url)
-        remote_thumbnail_url = urlparse.urlunsplit(
+        parse_result = urlsplit(remote_thumbnail_url)
+        remote_thumbnail_url = urlunsplit(
             ('', '', parse_result.path, parse_result.query, ''))
 
         response = self.client.get(remote_thumbnail_url)
@@ -623,8 +626,8 @@ class ThumbnailGenerationTest(GeoNodeBaseTestSupport):
         remote_thumbnail_url = remote_thumbnail_link.url
 
         # Replace url's basename, we want to access it using django client
-        parse_result = urlparse.urlsplit(remote_thumbnail_url)
-        remote_thumbnail_url = urlparse.urlunsplit(
+        parse_result = urlsplit(remote_thumbnail_url)
+        remote_thumbnail_url = urlunsplit(
             ('', '', parse_result.path, parse_result.query, ''))
 
         response = self.client.get(remote_thumbnail_url)

--- a/geonode/qgis_server/tests/test_xml_utilities.py
+++ b/geonode/qgis_server/tests/test_xml_utilities.py
@@ -50,7 +50,7 @@ class XMLUtilitiesTest(GeoNodeBaseTestSupport):
         element.text = 'TESTtext'
         result_xml = ElementTree.tostring(root)
 
-        self.assertEquals(expected_xml, result_xml)
+        self.assertEqual(expected_xml, result_xml)
 
     @on_ogc_backend(qgis_server.BACKEND_PACKAGE)
     def test_update_xml(self):

--- a/geonode/qgis_server/views.py
+++ b/geonode/qgis_server/views.py
@@ -18,7 +18,7 @@
 #
 #########################################################################
 
-import StringIO
+import io
 import json
 import logging
 import os
@@ -83,7 +83,7 @@ def download_zip(request, layername):
     zip_filename = "%s.zip" % zip_subdir
 
     # Open StringIO to grab in-memory ZIP contents
-    s = StringIO.StringIO()
+    s = io.StringIO()
 
     # The zip compressor
     zf = zipfile.ZipFile(s, "w")
@@ -155,7 +155,7 @@ def download_map(request, mapid):
     zip_filename = "%s.zip" % zip_subdir
 
     # Open StringIO to grab in-memory ZIP contents
-    s = StringIO.StringIO()
+    s = io.StringIO()
 
     # The zip compressor
     zf = zipfile.ZipFile(s, "w")
@@ -215,7 +215,7 @@ def legend(request, layername, layertitle=False, style=None):
             try:
                 style_list(layer, internal=False)
             except BaseException:
-                print 'Failed to fetch styles'
+                print("Failed to fetch styles")
 
             # refresh values
             qgis_layer.refresh_from_db()
@@ -307,7 +307,7 @@ def tile(request, layername, z, x, y, style=None):
             try:
                 style_list(layer, internal=False)
             except BaseException:
-                print 'Failed to fetch styles'
+                print("Failed to fetch styles")
 
             # refresh values
             qgis_layer.refresh_from_db()
@@ -408,8 +408,7 @@ def qgis_server_request(request):
     """View to forward OGC request to QGIS Server."""
     # Make a copy of the query string with capital letters for the key.
     query = request.GET or request.POST
-    params = {
-        param.upper(): value for param, value in query.iteritems()}
+    params = {param.upper(): value for param, value in query.items()}
 
     # 900913 is deprecated
     if params.get('SRS') == 'EPSG:900913':
@@ -527,11 +526,9 @@ def qgis_server_pdf(request):
 def qgis_server_map_print(request):
     logger.debug('qgis_server_map_print')
     temp = []
-    for key, value in request.POST.iteritems():
+    for key, value in request.POST.items():
         temp[key] = value
-        print key
-        print value
-        print '--------'
+        print("{}\n{}\n--------".format(key, value))
     return HttpResponse(
         json.dumps(temp), content_type="application/json")
 
@@ -556,7 +553,7 @@ def qml_style(request, layername, style_name=None):
             try:
                 styles_obj = style_list(layer, internal=False)
             except BaseException:
-                print 'Failed to fetch styles'
+                print("Failed to fetch styles")
 
             styles_dict = []
             if styles_obj:
@@ -655,7 +652,7 @@ def qml_style(request, layername, style_name=None):
                 try:
                     style_list(layer, internal=False)
                 except BaseException:
-                    print 'Failed to fetch styles'
+                    print("Failed to fetch styles")
 
                 return TemplateResponse(
                     request,
@@ -722,7 +719,7 @@ def qml_style(request, layername, style_name=None):
             try:
                 style_list(layer, internal=False)
             except BaseException:
-                print 'Failed to fetch styles'
+                print("Failed to fetch styles")
 
             return TemplateResponse(
                 request,

--- a/geonode/qgis_server/xml_utilities.py
+++ b/geonode/qgis_server/xml_utilities.py
@@ -125,7 +125,7 @@ def update_xml(xml_file, new_values):
     exml = etree.parse(xml_file)
     root = exml.getroot()
 
-    for name, path in properties.iteritems():
+    for name, path in properties.items():
         if name in new_values:
             elem = root.find(path, XML_NS)
             if elem is None:


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
