### PR TITLE
[Issue #4276] Upgrade services for Python 2.7/3 compatibility

### DIFF
--- a/geonode/services/management/commands/importservice.py
+++ b/geonode/services/management/commands/importservice.py
@@ -20,8 +20,13 @@
 
 from django.core.management.base import BaseCommand
 from geonode.services.models import Service
-from geonode.services.views import _register_cascaded_service, _register_indexed_service, \
-    _register_harvested_service, _register_cascaded_layers, _register_indexed_layers
+from geonode.services.views import (
+    _register_cascaded_service,
+    _register_indexed_service,
+    _register_harvested_service,
+    _register_cascaded_layers,
+    _register_indexed_layers,
+)
 import json
 from geonode.people.utils import get_valid_user
 import sys
@@ -68,7 +73,7 @@ class Command(BaseCommand):
         except Service.DoesNotExist:
             service = None
         if service is not None:
-            print "This is an existing Service"
+            print("This is an existing Service")
             register_service = False
             # Then Check that the name is Unique
         try:
@@ -76,7 +81,7 @@ class Command(BaseCommand):
         except Service.DoesNotExist:
             service = None
         if service is not None:
-            print "This is an existing service using this name.\nPlease specify a different name."
+            print("This is an existing service using this name.\nPlease specify a different name.")
         if register_service:
             if method == 'C':
                 response = _register_cascaded_service(type, url, name, username, password, owner=owner, verbosity=True)
@@ -85,22 +90,22 @@ class Command(BaseCommand):
             elif method == 'H':
                 response = _register_harvested_service(url, name, username, password, owner=owner, verbosity=True)
             elif method == 'X':
-                print 'Not Implemented (Yet)'
+                print("Not Implemented (Yet)")
             elif method == 'L':
-                print 'Local Services not configurable via API'
+                print("Local Services not configurable via API")
             else:
-                print 'Invalid method'
+                print("Invalid method")
 
             json_response = json.loads(response.content)
             if "id" in json_response:
-                print "Service created with id of %d" % json_response["id"]
+                print("Service created with id of {}".format(json_response["id"]))
                 service = Service.objects.get(id=json_response["id"])
             else:
-                print "Something went wrong: %s" % response.content
+                print("Something went wrong: {}".format(response.content))
                 return
 
-            print service.id
-            print register_layers
+            print(service.id)
+            print(register_layers)
 
         if service and register_layers:
             layers = []
@@ -111,10 +116,10 @@ class Command(BaseCommand):
             elif service.method == 'I':
                 response = _register_indexed_layers(user, service, layers, perm_spec)
             elif service.method == 'X':
-                print 'Not Implemented (Yet)'
+                print("Not Implemented (Yet)")
             elif service.method == 'L':
-                print 'Local Services not configurable via API'
+                print("Local Services not configurable via API")
             else:
-                print('Invalid Service Type')
+                print("Invalid Service Type")
 
-        print response.content
+        print(response.content)

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -26,7 +26,11 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from geonode.base.models import ResourceBase
 from geonode.people.enumerations import ROLE_VALUES
-from urlparse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urljoin
 
 from . import enumerations
 

--- a/geonode/services/serviceprocessors/base.py
+++ b/geonode/services/serviceprocessors/base.py
@@ -21,7 +21,11 @@
 
 import logging
 
-from urllib import quote
+try:
+    from urllib.parse import quote
+except ImportError:
+    # Python 2 compatibility
+    from urllib import quote
 
 from django.conf import settings
 from django.core.urlresolvers import reverse

--- a/geonode/services/serviceprocessors/handler.py
+++ b/geonode/services/serviceprocessors/handler.py
@@ -52,7 +52,7 @@ def get_service_handler(base_url, proxy_base=None, service_type=enumerations.AUT
         if service_type == enumerations.AUTO:
             to_check = handlers.keys()
         else:
-            to_check = [k for k, v in handlers.items() if v["OWS"]]
+            to_check = (k for k, v in handlers.items() if v["OWS"])
         for type_ in to_check:
             logger.debug("Checking {}...".format(type_))
             try:

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -25,7 +25,11 @@ import requests
 import traceback
 
 from uuid import uuid4
-from urlparse import urlsplit, urljoin
+try:
+    from urllib.parse import urlsplit, urljoin
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urlsplit, urljoin
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -165,7 +169,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
 
         """
         try:
-            contents_gen = self.parsed_service.contents.itervalues()
+            contents_gen = self.parsed_service.contents.values()
             return (r for r in contents_gen if not any(r.children))
         except BaseException:
             return None

--- a/geonode/services/test_selenium.py
+++ b/geonode/services/test_selenium.py
@@ -45,7 +45,7 @@ class WmsServiceHarvestingTestCase(StaticLiveServerTestCase):
             cls.selenium.refresh()
         except Exception as e:
             msg = str(e)
-            print msg
+            print(msg)
 
     @classmethod
     def tearDownClass(cls):

--- a/geonode/services/tests.py
+++ b/geonode/services/tests.py
@@ -257,7 +257,7 @@ class ModuleFunctionsTestCase(StandardTestCase):
         mock_map_service.return_value = (phony_url, mock_parsed_arcgis)
 
         handler = arcgis.ArcImageServiceHandler(phony_url)
-        self.assertEquals(handler.url, phony_url)
+        self.assertEqual(handler.url, phony_url)
 
         LayerESRIExtent = namedtuple('LayerESRIExtent', 'spatialReference xmin ymin ymax xmax')
         LayerESRIExtentSpatialReference = namedtuple('LayerESRIExtentSpatialReference', 'wkid latestWkid')
@@ -369,7 +369,7 @@ class ModuleFunctionsTestCase(StandardTestCase):
             maxScale=0
         )
         resource_fields = handler._get_indexed_layer_fields(layer_meta)
-        self.assertEquals(resource_fields['alternate'], '0-droits-ptroliers-et-gaziers-oil-and-gas-rights')
+        self.assertEqual(resource_fields['alternate'], '0-droits-ptroliers-et-gaziers-oil-and-gas-rights')
 
 
 class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
@@ -551,7 +551,7 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
     def test_local_user_cant_delete_service(self):
         self.client.logout()
         response = self.client.get(reverse('register_service'))
-        self.failUnlessEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         url = 'https://demo.geo-solutions.it/geoserver/ows?service=wms&version=1.3.0&request=GetCapabilities'
         # url = "http://fake"
         service_type = enumerations.WMS
@@ -566,15 +566,15 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
         response = self.client.post(reverse('register_service'), data=form_data)
 
         s = Service.objects.all().first()
-        self.failUnlessEqual(len(Service.objects.all()), 1)
+        self.assertEqual(len(Service.objects.all()), 1)
         self.assertEqual(s.owner, self.test_user)
 
         self.client.login(username='serviceuser', password='somepassword')
         response = self.client.post(reverse('edit_service', args=(s.id,)))
-        self.failUnlessEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 401)
         response = self.client.post(reverse('remove_service', args=(s.id,)))
-        self.failUnlessEqual(response.status_code, 401)
-        self.failUnlessEqual(len(Service.objects.all()), 1)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(len(Service.objects.all()), 1)
 
         self.client.login(username='serviceowner', password='somepassword')
         form_data = {
@@ -593,7 +593,7 @@ class WmsServiceHandlerTestCase(GeoNodeBaseTestSupport):
         self.assertEqual([u'Foo', u'OWS', u'Service'],
                          list(s.keywords.all().values_list('name', flat=True)))
         response = self.client.post(reverse('remove_service', args=(s.id,)))
-        self.failUnlessEqual(len(Service.objects.all()), 0)
+        self.assertEqual(len(Service.objects.all()), 0)
 
 
 class WmsServiceHarvestingTestCase(StaticLiveServerTestCase):
@@ -633,7 +633,7 @@ class WmsServiceHarvestingTestCase(StaticLiveServerTestCase):
             cls.selenium.refresh()
         except Exception as e:
             msg = str(e)
-            print msg
+            print(msg)
 
     @classmethod
     def tearDownClass(cls):

--- a/geonode/services/views.py
+++ b/geonode/services/views.py
@@ -37,8 +37,13 @@ from django.contrib.auth.decorators import login_required
 from geonode.security.views import _perms_info_json
 from geonode.layers.models import Layer
 from geonode.proxy.views import proxy
-from urlparse import urljoin
-from urllib import quote
+try:
+    from urllib.parse import urljoin
+    from urllib.parse import quote
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urljoin
+    from urllib import quote
 from .serviceprocessors import get_service_handler
 from . import enumerations
 from . import forms


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
