### PR TITLE
[Issue #4276] Upgrade geonode for Python 2.7/3 compatibility

### DIFF
--- a/geonode/decorators.py
+++ b/geonode/decorators.py
@@ -69,7 +69,7 @@ def view_decorator(fdec, subclass=False):
         if subclass:
             cls = type("%sWithDecorator(%s)" %
                        (cls.__name__, fdec.__name__), (cls,), {})
-        original = cls.as_view.im_func
+        original = cls.as_view.__func__
 
         @wraps(original)
         def as_view(current, **initkwargs):

--- a/geonode/middleware.py
+++ b/geonode/middleware.py
@@ -33,8 +33,8 @@ class PrintProxyMiddleware(object):
 
 
 def print_map(request):
-    from proxy.views import proxy
-    from layers.models import Layer
+    from .proxy.views import proxy
+    from .layers.models import Layer
 
     permissions = {}
     params = json.loads(request.body)

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -25,7 +25,11 @@ import re
 import sys
 from datetime import timedelta
 from distutils.util import strtobool  # noqa
-from urlparse import urlparse, urlunparse, urljoin
+try:
+    from urllib.parse import urlparse, urlunparse, urljoin
+except ImportError:
+    # Python 2 compatibility
+    from urlparse import urlparse, urlunparse, urljoin
 
 import django
 import dj_database_url
@@ -1558,8 +1562,8 @@ if GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY == 'mapstore':
     MAPSTORE_CATALOGUE_SELECTED_SERVICE = "Demo WMS Service"
 
     if GEONODE_CATALOGUE_SERVICE:
-        MAPSTORE_CATALOGUE_SERVICES[GEONODE_CATALOGUE_SERVICE.keys()[0]] = GEONODE_CATALOGUE_SERVICE[GEONODE_CATALOGUE_SERVICE.keys()[0]]
-        MAPSTORE_CATALOGUE_SELECTED_SERVICE = GEONODE_CATALOGUE_SERVICE.keys()[0]
+        MAPSTORE_CATALOGUE_SERVICES[list(GEONODE_CATALOGUE_SERVICE.keys())[0]] = GEONODE_CATALOGUE_SERVICE[list(GEONODE_CATALOGUE_SERVICE.keys())[0]]
+        MAPSTORE_CATALOGUE_SELECTED_SERVICE = list(GEONODE_CATALOGUE_SERVICE.keys())[0]
 
         DEFAULT_MS2_BACKGROUNDS = [
             {

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -40,7 +40,7 @@ import subprocess
 
 from osgeo import ogr
 from slugify import slugify
-from StringIO import StringIO
+from io import StringIO
 from contextlib import closing
 from math import atan, exp, log, pi, sin, tan, floor
 from zipfile import ZipFile, is_zipfile, ZIP_DEFLATED
@@ -547,7 +547,7 @@ class GXPMapBase(object):
             server_lookup[json.dumps(source)] = str(i)
 
         def source_lookup(source):
-            for k, v in sources.iteritems():
+            for k, v in sources.items():
                 if v == source:
                     return k
             return None
@@ -682,7 +682,7 @@ class GXPLayerBase(object):
             Will also override any access_token in the request and replace it with an existing one.
             '''
             urls = []
-            for name, server in settings.OGC_SERVER.iteritems():
+            for name, server in settings.OGC_SERVER.items():
                 url = urlsplit(server['PUBLIC_LOCATION'])
                 urls.append(url.netloc)
 


### PR DESCRIPTION
<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [ ] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [ ] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in documentation)
- [ ] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemptions is, changes not visible to end users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [ ] PR for bug fixes and small new features are presented as a single commit
- [ ] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [ ] New unit tests have been added covering the changes, unless there are explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
